### PR TITLE
Betterbetterblittle

### DIFF
--- a/betterblittle.lua
+++ b/betterblittle.lua
@@ -96,12 +96,12 @@ local function getCharFomPixelGroup(c1, c2, p1, p2, p3, p4, p5, p6)
 	local c1Dist = colorDistances[c1]
 	local c2Dist = colorDistances[c2]
 	local charNr = 128
-	if p1 == c1 or p1 ~= c2 and c1Dist[p1] < c2Dist[p1] then charNr = charNr + 1 end
-	if p2 == c1 or p2 ~= c2 and c1Dist[p2] < c2Dist[p2] then charNr = charNr + 2 end
-	if p3 == c1 or p3 ~= c2 and c1Dist[p3] < c2Dist[p3] then charNr = charNr + 4 end
-	if p4 == c1 or p4 ~= c2 and c1Dist[p4] < c2Dist[p4] then charNr = charNr + 8 end
-	if p5 == c1 or p5 ~= c2 and c1Dist[p5] < c2Dist[p5] then charNr = charNr + 16 end
-	if p6 == c1 or p6 ~= c2 and c1Dist[p6] < c2Dist[p6] then
+	if c1Dist[p1] < c2Dist[p1] then charNr = charNr + 1 end
+	if c1Dist[p2] < c2Dist[p2] then charNr = charNr + 2 end
+	if c1Dist[p3] < c2Dist[p3] then charNr = charNr + 4 end
+	if c1Dist[p4] < c2Dist[p4] then charNr = charNr + 8 end
+	if c1Dist[p5] < c2Dist[p5] then charNr = charNr + 16 end
+	if c1Dist[p6] < c2Dist[p6] then
 		return allChars[bxor(31, charNr)], true
 	end
 	return allChars[charNr], false

--- a/betterblittle.lua
+++ b/betterblittle.lua
@@ -4,8 +4,11 @@ local floor = math.floor
 local min = math.min
 local concat = table.concat
 
+local colorMap = {}
+for i = 1, 16 do colorMap[2 ^ (i - 1)] = i end
+
 local colorChar = {}
-for i = 1, 16 do colorChar[2 ^ (i - 1)] = ("0123456789abcdef"):sub(i, i) end
+for i = 1, 16 do colorChar[i] = ("0123456789abcdef"):sub(i, i) end
 
 local colorDistances
 
@@ -77,16 +80,10 @@ local function computeColorDistances(window, colorSpace)
 		for c2 = 1, 16 do
 			local r2, g2, b2 = window.getPaletteColor(2 ^ (c2 - 1))
 			if colorSpace ~= "sRGB" then r2, g2, b2 = sRGBtoOklab(r2, g2, b2) end
-			local d = (r2 - r1) ^ 2 + (g2 - g1) ^ 2 + (b2 - b1) ^ 2
-			distances[2 ^ (c2 - 1)] = d
+			distances[c2] = (r2 - r1) ^ 2 + (g2 - g1) ^ 2 + (b2 - b1) ^ 2
 		end
-		colorDistances[2 ^ (c1 - 1)] = distances
+		colorDistances[c1] = distances
 	end
-end
-
-local function colorCloser(target, c1, c2)
-	local dists = colorDistances[target]
-	return dists[c1] < dists[c2]
 end
 
 local char = string.char
@@ -94,14 +91,15 @@ local allChars = {}
 for i = 128, 128+31 do allChars[i] = char(i) end
 local bxor = bit.bxor
 local function getCharFomPixelGroup(c1, c2, p1, p2, p3, p4, p5, p6)
-	local cc = colorCloser
+	local c1Dist = colorDistances[c1]
+	local c2Dist = colorDistances[c2]
 	local charNr = 128
-	if p1 == c1 or p1 ~= c2 and cc(p1, c1, c2) then charNr = charNr + 1 end
-	if p2 == c1 or p2 ~= c2 and cc(p2, c1, c2) then charNr = charNr + 2 end
-	if p3 == c1 or p3 ~= c2 and cc(p3, c1, c2) then charNr = charNr + 4 end
-	if p4 == c1 or p4 ~= c2 and cc(p4, c1, c2) then charNr = charNr + 8 end
-	if p5 == c1 or p5 ~= c2 and cc(p5, c1, c2) then charNr = charNr + 16 end
-	if p6 == c1 or p6 ~= c2 and cc(p6, c1, c2) then
+	if p1 == c1 or p1 ~= c2 and c1Dist[p1] < c2Dist[p1] then charNr = charNr + 1 end
+	if p2 == c1 or p2 ~= c2 and c1Dist[p2] < c2Dist[p2] then charNr = charNr + 2 end
+	if p3 == c1 or p3 ~= c2 and c1Dist[p3] < c2Dist[p3] then charNr = charNr + 4 end
+	if p4 == c1 or p4 ~= c2 and c1Dist[p4] < c2Dist[p4] then charNr = charNr + 8 end
+	if p5 == c1 or p5 ~= c2 and c1Dist[p5] < c2Dist[p5] then charNr = charNr + 16 end
+	if p6 == c1 or p6 ~= c2 and c1Dist[p6] < c2Dist[p6] then
 		return allChars[bxor(31, charNr)], true
 	end
 	return allChars[charNr], false
@@ -130,12 +128,12 @@ local function drawBuffer(buffer, win)
 		for x = 1, maxX do
 			local ox = (x-1) * 2 + 1
 
-			local p1 = r1[ox]
-			local p2 = r1[ox+1]
-			local p3 = r2[ox]
-			local p4 = r2[ox+1]
-			local p5 = r3[ox]
-			local p6 = r3[ox+1]
+			local p1 = colorMap[r1[ox]]
+			local p2 = colorMap[r1[ox+1]]
+			local p3 = colorMap[r2[ox]]
+			local p4 = colorMap[r2[ox+1]]
+			local p5 = colorMap[r3[ox]]
+			local p6 = colorMap[r3[ox+1]]
 			if p1 == p2 and p2 == p3 and p3 == p4 and p4 == p5 and p5 == p6 then
 				local c = colorChar[p1]
 				blitC1[x] = c

--- a/betterblittle.lua
+++ b/betterblittle.lua
@@ -12,25 +12,28 @@ for i = 1, 16 do colorChar[i] = ("0123456789abcdef"):sub(i, i) end
 local colorDistances
 
 local function getColorsFromPixelGroup(p1, p2, p3, p4, p5, p6)
-	local freq = {}
+	local freq = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	freq[p1] = 1
-	freq[p2] = (freq[p2] or 0) + 1
-	freq[p3] = (freq[p3] or 0) + 1
-	freq[p4] = (freq[p4] or 0) + 1
-	freq[p5] = (freq[p5] or 0) + 1
-	freq[p6] = (freq[p6] or 0) + 1
+	freq[p2] = freq[p2] + 1
+	freq[p3] = freq[p3] + 1
+	freq[p4] = freq[p4] + 1
+	freq[p5] = freq[p5] + 1
+	freq[p6] = freq[p6] + 1
 
 	local c1 = p1
 	local c2 = p1
 	local totalColors = 0
 	local highestCount = 0
-	for color, count in pairs(freq) do
-		totalColors = totalColors + 1
-		if color ~= c1 then c2 = color end
-		if count > highestCount then
-			c2 = c1
-			c1 = color
-			highestCount = count
+	for color = 1, 16 do
+		local count = freq[color]
+		if count > 0 then
+			totalColors = totalColors + 1
+			if color ~= c1 then c2 = color end
+			if count > highestCount then
+				c2 = c1
+				c1 = color
+				highestCount = count
+			end
 		end
 	end
 
@@ -39,9 +42,9 @@ local function getColorsFromPixelGroup(p1, p2, p3, p4, p5, p6)
 	local bestC2 = p1
 	local lowestError = 99
 	local c1Dists = colorDistances[c1]
-	for c2, _ in pairs(freq) do
-		local c2Dists = colorDistances[c2]
-		if c2 ~= c1 then
+	for c2 = 1, 16 do
+		if c2 ~= c1 and freq[c2] > 0 then
+			local c2Dists = colorDistances[c2]
 			local err = min(c1Dists[p1], c2Dists[p1]) + min(c1Dists[p2], c2Dists[p2]) + min(c1Dists[p3], c2Dists[p3])
 				+ min(c1Dists[p4], c2Dists[p4]) + min(c1Dists[p5], c2Dists[p5]) + min(c1Dists[p6], c2Dists[p6])
 			if err < lowestError then

--- a/betterblittle.lua
+++ b/betterblittle.lua
@@ -1,5 +1,4 @@
 -- Made by Xella
-
 local floor = math.floor
 local min = math.min
 local concat = table.concat
@@ -88,7 +87,7 @@ end
 
 local char = string.char
 local allChars = {}
-for i = 128, 128+31 do allChars[i] = char(i) end
+for i = 128, 128 + 31 do allChars[i] = char(i) end
 local bxor = bit.bxor
 local function getCharFomPixelGroup(c1, c2, p1, p2, p3, p4, p5, p6)
 	local c1Dist = colorDistances[c1]
@@ -105,35 +104,43 @@ local function getCharFomPixelGroup(c1, c2, p1, p2, p3, p4, p5, p6)
 	return allChars[charNr], false
 end
 
-local function drawBuffer(buffer, win)
+---Draw a color buffer to the window
+---@param buffer integer[][] 2D array of colors to display
+---@param window Redirect
+---@param wx integer? x position on monitor (in terminal character pixels)
+---@param wy integer? y position on monitor (in terminal character pixels)
+local function drawBuffer(buffer, window, wx, wy)
+	wx = wx or 1
+	wy = wy or 1
+
 	local height = #buffer
 	local width = #buffer[1]
 
-	if not colorDistances then computeColorDistances(win) end
+	if not colorDistances then computeColorDistances(window) end
 
 	local maxX = floor(width / 2)
-	local setCursorPos = win.setCursorPos
-	local blit = win.blit
+	local setCursorPos = window.setCursorPos
+	local blit = window.blit
 	local colorChar = colorChar
-	for y = 1, floor(height / 3) do
-		local oy = (y-1) * 3 + 1
+	for y = 0, floor(height / 3) - 1 do
+		local oy = y * 3 + 1
 
 		local r1 = buffer[oy] -- first row from buffer for this row of characters
-		local r2 = buffer[oy+1] -- second row from buffer for this row of characters
-		local r3 = buffer[oy+2] -- third row from buffer for this row of characters
+		local r2 = buffer[oy + 1] -- second row from buffer for this row of characters
+		local r3 = buffer[oy + 2] -- third row from buffer for this row of characters
 
 		local blitC1 = {nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
 		local blitC2 = {nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
 		local blitChar = {nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}
 		for x = 1, maxX do
-			local ox = (x-1) * 2 + 1
+			local ox = (x - 1) * 2 + 1
 
 			local p1 = colorMap[r1[ox]]
-			local p2 = colorMap[r1[ox+1]]
+			local p2 = colorMap[r1[ox + 1]]
 			local p3 = colorMap[r2[ox]]
-			local p4 = colorMap[r2[ox+1]]
+			local p4 = colorMap[r2[ox + 1]]
 			local p5 = colorMap[r3[ox]]
-			local p6 = colorMap[r3[ox+1]]
+			local p6 = colorMap[r3[ox + 1]]
 			if p1 == p2 and p2 == p3 and p3 == p4 and p4 == p5 and p5 == p6 then
 				local c = colorChar[p1]
 				blitC1[x] = c
@@ -160,7 +167,7 @@ local function drawBuffer(buffer, win)
 		local c1 = con(blitChar)
 		local c2 = con(blitC1)
 		local c3 = con(blitC2)
-		setCursorPos(1, y)
+		setCursorPos(wx, wy + y)
 		blit(c1, c2, c3)
 	end
 end


### PR DESCRIPTION
- Use the [Oklab color space](https://bottosson.github.io/posts/oklab/) to compare colors
- Better algorithm for selecting the best two colors for a character with more than two colors, this new algorithm takes color distances into account
- Add `x, y` position to `drawBuffer` function to easily draw a buffer at a certain location
- Improved performance by mapping colors to values between 1 and 16

Current performance compared to current main BetterBlittle version[^1]:
|                     | CraftOS-PC  | CraftOS-PC Accelerated |
| ------------------- | ----------- | ---------------------- |
| Default screen size | 6.5% slower | 36.6% faster           |
| Full screen (1440p) | 7.8% slower | 46.5% faster           |

[^1]: Based on a test drawing many frame buffers filled with random colors